### PR TITLE
fix/issue-54,支付结果页如果支付状态为未支付,增加刷新按钮

### DIFF
--- a/app/View/User/Theme/Cartoon/Index/Query.html
+++ b/app/View/User/Theme/Cartoon/Index/Query.html
@@ -48,7 +48,7 @@
         Pay.getQuery(keywords, res => {
             res.forEach(order => {
                 if (order.commodity && order.pay) {
-                    let status = '<span style="color: red;">未支付</span>';
+                    let status = '<span style="color: red;">未支付</span> <b style="cursor:pointer;color: blue;" class="queryBtn">刷新</b>';
                     if (order.status === 1) {
                         status = '<span style="color: green;">已支付</span>';
                     }
@@ -104,7 +104,7 @@
         });
     }
 
-    $('.queryBtn').click(function () {
+    $(document).on('click', '.queryBtn', function() {
         query(keywordsIns.val());
     });
 


### PR DESCRIPTION
问题背景
[https://github.com/lizhipay/acg-faka/issues/54](url)
支付完成后跳转到结果页,查询显示未支付(实际已支付),需等待几秒后再次手动查询,才会更新为已支付

由于我不是php开发者,能力有限,通过下列方式对本问题进行优化:如果支付状态为未支付,增加一个刷新按钮,允许用户手动触发刷新,如下图
![微信截图_20230606111737](https://github.com/lizhipay/acg-faka/assets/10990830/0bbe07ec-0b14-495e-9d42-f525f483ef93)
刷新后状态置为已支付,不再显示刷新按钮,如下图
![微信截图_20230606111748](https://github.com/lizhipay/acg-faka/assets/10990830/c05163ea-710f-4b51-8d64-51328441837b)
