### PR TITLE
fix: PHP constraint should be ">=8.0.2"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "source": "https://github.com/lizhipay/acg-faka"
   },
   "require": {
-    "php": ">=8.0.0",
+    "php": ">=8.0.2",
     "smarty/smarty": "~3.1",
     "illuminate/database": "^7.30.6",
     "symfony/var-dumper": "^5.1",


### PR DESCRIPTION
Some dependencies need PHP version >=8.0.2, and the current constraint of PHP is >=8.0.0, which is incompatible to those dependencies.

https://github.com/lizhipay/acg-faka/blob/a1afb5b9984d3d868f1195bcd84ba75f3ad68767/composer.lock#L2215-L2234
