### PR TITLE
修复acg-faka用epusdt收款验签失败的错误

### DIFF
--- a/app/Controller/User/Api/Order.php
+++ b/app/Controller/User/Api/Order.php
@@ -51,6 +51,10 @@ class Order extends User
             $data = $_REQUEST;
             unset($data['s']);
         }
+        if (empty($data) && isset($_SERVER['CONTENT_TYPE']) && $_SERVER['CONTENT_TYPE'] == 'application/json') {
+            $json_string = file_get_contents('php://input');
+            $data = json_decode($json_string, true);
+        }
         return $this->order->callback($handle, $data);
     }
 

--- a/app/Controller/User/Api/RechargeNotification.php
+++ b/app/Controller/User/Api/RechargeNotification.php
@@ -26,8 +26,10 @@ class RechargeNotification extends User
             $data = $_REQUEST;
             unset($data['s']);
         }
-
-
+        if (empty($data) && isset($_SERVER['CONTENT_TYPE']) && $_SERVER['CONTENT_TYPE'] == 'application/json') {
+            $json_string = file_get_contents('php://input');
+            $data = json_decode($json_string, true);
+        }
         return $this->recharge->callback($handle, $data);
     }
 }


### PR DESCRIPTION
关于issue #22 的一个解决方法。

还需要修改acg-faka的epusdt插件：

路径：app/Pay/Epusdt/Impl/Signature.php

```php
   public static function generateSignature(array $data, string $key): string
    {
        ksort($data);
        reset($data);
        $sign = '';
        foreach ($data as $k => $v) {
            if ($v == '') continue;
            $sign .= $k . '=' . $v . '&';
        }
        $sign = trim($sign, '&');
        return md5($sign . $key);
    }
```