### PR TITLE
Fix theme selection being reverted after saving settings

### DIFF
--- a/app/Controller/Admin/Api/Config.php
+++ b/app/Controller/Admin/Api/Config.php
@@ -59,6 +59,8 @@ class Config extends Manage
                 Client::setClientMode((int)$post['ip_get_mode']);
             }
 
+            _plugin_start($post['user_theme'], true);
+
             foreach ($keys as $index => $key) {
                 if (in_array($key, $inits)) {
                     if (!isset($post[$key])) {
@@ -71,7 +73,6 @@ class Config extends Manage
             throw new JSONException("保存失败，请检查原因");
         }
 
-        _plugin_start($post['user_theme'], true);
         ManageLog::log($this->getManage(), "修改了网站设置");
         return $this->json(200, '保存成功');
     }


### PR DESCRIPTION
## Summary

Fix a theme settings persistence issue in the admin site settings page.

When saving `/admin/api/config/setting`, the current flow writes config values first and then calls `_plugin_start(['user_theme'], true)`. For a locally installed theme, that validation/startup step can revert `user_theme` back to the default theme after the API has already returned a successful save.

This change runs the theme startup validation before persisting the submitted config values, so the final saved `user_theme` matches the admin form submission.

## Reproduction

1. Place a valid local theme under `app/View/User/Theme/<ThemeName>`.
2. Open admin site settings.
3. Select the local theme as the PC theme and save.
4. The API returns `保存成功`.
5. Check `config.user_theme`: it is reverted to the default theme instead of the selected theme.

## Verification

Tested with a local theme:

- Before this change: saving returns success, but `user_theme` becomes `Cartoon`.
- After this change: saving returns success, and `user_theme` remains the selected theme.
- `php -l app/Controller/Admin/Api/Config.php` passes.

## Scope and limitations

This change is intentionally a minimal workaround at the call site, not a root-cause fix.

- The underlying side effect lives in `_plugin_start(..., true)`, which is defined in `kernel/Plugin.php`. That file is shipped as a `gzinflate`-encoded blob, so its body cannot be modified in this PR.
- By reordering the call, the subsequent `CFG::put('user_theme', $post['user_theme'])` overwrites whatever `_plugin_start` writes back, which is why the user-visible bug disappears. The side effect inside `_plugin_start` itself is unchanged.
- The other in-repo caller, `app/Controller/Admin/Api/Plugin.php:109`, invokes `_plugin_start($id)` without the second `true` argument and does not appear to hit the same revert path, so the admin settings save is the only call site this PR needs to touch.
- A proper fix would remove the `user_theme` write-back inside `_plugin_start` (or stop calling it from the save handler entirely) once the kernel source is editable. Maintainers with access to the unpacked kernel may prefer that route; in that case this PR can be closed in favor of the upstream fix.
