### PR TITLE
fix: 卡密导出文件名数量恒显示为 (2)

### DIFF
--- a/app/Controller/Admin/Api/Card.php
+++ b/app/Controller/Admin/Api/Card.php
@@ -296,10 +296,10 @@ class Card extends Manage
             \App\Model\Card::query()->whereIn('id', $ids)->whereRaw("status!=1")->update(['status' => 1, 'purchase_time' => Date::current()]);
         }
 
-        ManageLog::log($this->getManage(), "[卡密导出]导出卡密，共计：" . count($data));
+        ManageLog::log($this->getManage(), "[卡密导出]导出卡密，共计：" . count($data['list']));
         header('Content-Type:application/octet-stream');
         header('Content-Transfer-Encoding:binary');
-        header('Content-Disposition:attachment; filename=卡密导出(' . count($data) . ')-' . Date::current() . '.txt');
+        header('Content-Disposition:attachment; filename=卡密导出(' . count($data['list']) . ')-' . Date::current() . '.txt');
         return $card;
     }
 }


### PR DESCRIPTION
## 问题

后台「卡密管理 → 导出筛选卡密」时，无论实际导出多少条，下载文件名中的数量永远是 `(2)`，例如 `卡密导出(2)-2026-06-30 11_28_00.txt`。

## 根因

`app/Controller/Admin/Api/Card.php` 的 `export()` 中，文件名数量取自 `count($data)`：

```php
header('Content-Disposition:attachment; filename=卡密导出(' . count($data) . ')-' . Date::current() . '.txt');
```

但 $data 是 `$this->query->get()` 返回的分页结构 `["list" => [...], "total" => N]`，顶层键数恒为 2，所以 `count($data)` 永远等于 2。同一处的导出日志 `[卡密导出]导出卡密，共计：` 也是同样的问题。

## 修复

改用 `count($data['list'])` 取实际导出的卡密条数（日志与文件名两处）。